### PR TITLE
Add OneOf and OneOfDict

### DIFF
--- a/deeptrack/features.py
+++ b/deeptrack/features.py
@@ -1259,13 +1259,11 @@ class OneOf(Feature):
     """
 
     def __init__(self, collection, key=None, **kwargs):
-
         self.collection = tuple(collection)
+        super().__init__(key=key, **kwargs)
 
         for feature in self.collection:
             self.add_feature(feature)
-
-        super().__init__(key=key, **kwargs)
 
     def get(self, image, key, **kwargs):
 

--- a/deeptrack/features.py
+++ b/deeptrack/features.py
@@ -1267,11 +1267,13 @@ class OneOf(Feature):
         for feature in self.collection:
             self.add_feature(feature)
 
+    def _process_properties(self, propertydict) -> dict:
+        super()._process_properties(propertydict)
+
+        if propertydict["key"] is None:
+            propertydict["key"] = np.random.randint(len(self.collection))
+
     def get(self, image, key, **kwargs):
-
-        if key is None:
-            key = lambda: np.random.randint(len(self.collection))
-
         return self.collection[key](image)
 
 
@@ -1294,9 +1296,13 @@ class OneOfDict(Feature):
         for feature in self.collection.values():
             self.add_feature(feature)
 
+    def _process_properties(self, propertydict) -> dict:
+        super()._process_properties(propertydict)
+
+        if propertydict["key"] is None:
+            propertydict["key"] = np.random.choice(list(self.collection.keys()))
+
     def get(self, image, key, **kwargs):
-        if key is None:
-            key = lambda: np.random.choice(list(self.collection.keys()))
         return self.collection[key](image)
 
 

--- a/deeptrack/features.py
+++ b/deeptrack/features.py
@@ -1273,6 +1273,8 @@ class OneOf(Feature):
         if propertydict["key"] is None:
             propertydict["key"] = np.random.randint(len(self.collection))
 
+        return propertydict
+
     def get(self, image, key, **kwargs):
         return self.collection[key](image)
 
@@ -1301,6 +1303,8 @@ class OneOfDict(Feature):
 
         if propertydict["key"] is None:
             propertydict["key"] = np.random.choice(list(self.collection.keys()))
+
+        return propertydict
 
     def get(self, image, key, **kwargs):
         return self.collection[key](image)

--- a/deeptrack/features.py
+++ b/deeptrack/features.py
@@ -1258,6 +1258,8 @@ class OneOf(Feature):
     `tuple(collection)[key]`.
     """
 
+    __distributed__ = False
+
     def __init__(self, collection, key=None, **kwargs):
         self.collection = tuple(collection)
         super().__init__(key=key, **kwargs)

--- a/deeptrack/features.py
+++ b/deeptrack/features.py
@@ -1265,12 +1265,12 @@ class OneOf(Feature):
         for feature in self.collection:
             self.add_feature(feature)
 
-        if key is None:
-            key = lambda: np.random.randint(len(self.collection))
-
         super().__init__(key=key, **kwargs)
 
     def get(self, image, key, **kwargs):
+
+        if key is None:
+            key = lambda: np.random.randint(len(self.collection))
 
         return self.collection[key](image)
 
@@ -1289,15 +1289,14 @@ class OneOfDict(Feature):
 
         self.collection = collection
 
-        if key is None:
-            key = lambda: np.random.choice(list(self.collection.keys()))
-
         super().__init__(key=key, **kwargs)
 
         for feature in self.collection.values():
             self.add_feature(feature)
 
     def get(self, image, key, **kwargs):
+        if key is None:
+            key = lambda: np.random.choice(list(self.collection.keys()))
         return self.collection[key](image)
 
 

--- a/deeptrack/features.py
+++ b/deeptrack/features.py
@@ -1247,6 +1247,60 @@ class Merge(Feature):
         return function(list_of_images)
 
 
+class OneOf(Feature):
+    """Resolves one feature from a collection on the input.
+
+    Valid collections are any object that can be iterated (such as lists, tuples and sets).
+    Internally, the collection is converted to a tuple.
+
+    Default behaviour is to sample the collection uniformly random. This can be
+    controlled by the `key` argument, where the feature resolved is chosen as
+    `tuple(collection)[key]`.
+    """
+
+    def __init__(self, collection, key=None, **kwargs):
+
+        self.collection = tuple(collection)
+
+        for feature in self.collection:
+            self.add_feature(feature)
+
+        if key is None:
+            key = lambda: np.random.randint(len(self.collection))
+
+        super().__init__(key=key, **kwargs)
+
+    def get(self, image, key, **kwargs):
+
+        return self.collection[key](image)
+
+
+class OneOfDict(Feature):
+    """Resolves one feature from a dictionary.
+
+    Default behaviour is to sample the values diction uniformly random. This can be
+    controlled by the `key` argument, where the feature resolved is chosen as
+    `collection[key]`.
+    """
+
+    __distributed__ = False
+
+    def __init__(self, collection, key=None, **kwargs):
+
+        self.collection = collection
+
+        if key is None:
+            key = lambda: np.random.choice(list(self.collection.keys()))
+
+        super().__init__(key=key, **kwargs)
+
+        for feature in self.collection.values():
+            self.add_feature(feature)
+
+    def get(self, image, key, **kwargs):
+        return self.collection[key](image)
+
+
 class Dataset(Feature):
     """Grabs data from a local set of data.
 

--- a/deeptrack/test/test_features.py
+++ b/deeptrack/test/test_features.py
@@ -11,7 +11,6 @@ from numpy.testing._private.utils import assert_almost_equal
 
 from .. import features, Image, properties, utils
 
-from ..image import array
 
 import numpy as np
 import numpy.testing
@@ -58,13 +57,13 @@ def grid_test_features(
 
         if isinstance(output, list) and isinstance(expected_result, list):
             [
-                np.testing.assert_almost_equal(array(a), array(b))
+                np.testing.assert_almost_equal(np.array(a), np.array(b))
                 for a, b in zip(output, expected_result)
             ]
 
         else:
             is_equal = np.array_equal(
-                array(output), array(expected_result), equal_nan=True
+                np.array(output), np.array(expected_result), equal_nan=True
             )
 
             tester.failIf(
@@ -795,6 +794,124 @@ class TestFeatures(unittest.TestCase):
 
         res = pipeline.update().resolve(is_condition=True)
         self.assertEqual(res, 2)
+
+    def test_OneOfList(self):
+
+        values = features.OneOf(
+            [features.Value(1), features.Value(2), features.Value(3)]
+        )
+
+        has_been_one = False
+        has_been_two = False
+        has_been_three = False
+
+        for _ in range(50):
+            val = values.update().resolve()
+            self.assertIn(val, [1, 2, 3])
+            if val == 1:
+                has_been_one = True
+            elif val == 2:
+                has_been_two = True
+            else:
+                has_been_three = True
+        self.assertTrue(has_been_one)
+        self.assertTrue(has_been_two)
+        self.assertTrue(has_been_three)
+
+        self.assertEquals(values.update().resolve(key=0), 1)
+
+        self.assertEquals(values.update().resolve(key=1), 2)
+
+        self.assertEquals(values.update().resolve(key=2), 3)
+
+        self.assertRaises(IndexError, lambda: values.update().resolve(key=3))
+
+    def test_OneOfTuple(self):
+
+        values = features.OneOf(
+            (features.Value(1), features.Value(2), features.Value(3))
+        )
+
+        has_been_one = False
+        has_been_two = False
+        has_been_three = False
+
+        for _ in range(50):
+            val = values.update().resolve()
+            self.assertIn(val, [1, 2, 3])
+            if val == 1:
+                has_been_one = True
+            elif val == 2:
+                has_been_two = True
+            else:
+                has_been_three = True
+        self.assertTrue(has_been_one)
+        self.assertTrue(has_been_two)
+        self.assertTrue(has_been_three)
+
+        self.assertEquals(values.update().resolve(key=0), 1)
+
+        self.assertEquals(values.update().resolve(key=1), 2)
+
+        self.assertEquals(values.update().resolve(key=2), 3)
+
+        self.assertRaises(IndexError, lambda: values.update().resolve(key=3))
+
+    def test_OneOfSet(self):
+
+        values = features.OneOf(
+            set([features.Value(1), features.Value(2), features.Value(3)])
+        )
+
+        has_been_one = False
+        has_been_two = False
+        has_been_three = False
+
+        for _ in range(50):
+            val = values.update().resolve()
+            self.assertIn(val, [1, 2, 3])
+            if val == 1:
+                has_been_one = True
+            elif val == 2:
+                has_been_two = True
+            else:
+                has_been_three = True
+        self.assertTrue(has_been_one)
+        self.assertTrue(has_been_two)
+        self.assertTrue(has_been_three)
+
+        self.assertRaises(IndexError, lambda: values.update().resolve(key=3))
+
+    def test_OneOfDict(self):
+
+        values = features.OneOfDict(
+            {"1": features.Value(1), "2": features.Value(2), "3": features.Value(3)}
+        )
+
+        has_been_one = False
+        has_been_two = False
+        has_been_three = False
+
+        for _ in range(50):
+            val = values.update().resolve()
+            self.assertIn(val, [1, 2, 3])
+            if val == 1:
+                has_been_one = True
+            elif val == 2:
+                has_been_two = True
+            else:
+                has_been_three = True
+        self.assertTrue(has_been_one)
+        self.assertTrue(has_been_two)
+        self.assertTrue(has_been_three)
+
+        self.assertEquals(values.update().resolve(key="1"), 1)
+
+        self.assertEquals(values.update().resolve(key="2"), 2)
+
+        self.assertEquals(values.update().resolve(key="3"), 3)
+
+        self.assertRaises(KeyError, lambda: values.update().resolve(key="4"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added two features, OneOf and OneOfDict. They resolve one feature out of a collection of features. Per default the feature is randomly sampled, but it can be customized by the `key` argument. This is to facilitate pipelines where, for example, one of several types of scatterers should be imaged. The syntax would be

```py
image = optics(
    dt.OneOf([scatterer_1, scatterer_2, scatterer_3])
)
```
or
```py
image = optics(
    dt.OneOfDict({"p1":scatterer_1, "p2":scatterer_2, "p3":scatterer_3])
)
```