### PR TITLE
Ensure code runs without cupy

### DIFF
--- a/deeptrack/backend/_config.py
+++ b/deeptrack/backend/_config.py
@@ -1,17 +1,28 @@
-__all__ = ["config"]
+__all__ = ["config", "cupy", "CUPY_AVAILABLE"]
+
+import warnings
+import numpy as cupy
+
+CUPY_AVAILABLE = True
+try:
+    import cupy
+except ImportError:
+    CUPY_AVAILABLE = False
+    warnings.warn(
+        "cupy not installed. GPU-accelerated simulations will not be possible"
+    )
 
 
 class Config:
     def __init__(self):
-        try:
-            self.enable_gpu()
-        except:
-            self.gpu_enabled = False
+        self.disable_gpu()
+        self.enable_gpu()
 
     def enable_gpu(self):
-        import cupy
-
-        self.gpu_enabled = True
+        if CUPY_AVAILABLE:
+            self.gpu_enabled = True
+        else:
+            warnings.warn("cupy not installed, CPU acceleration not enabled")
 
     def disable_gpu(self):
         self.gpu_enabled = False

--- a/deeptrack/backend/mie.py
+++ b/deeptrack/backend/mie.py
@@ -1,7 +1,7 @@
 """ Perform Mie-specific calculations
 """
 
-import cupy
+from ._config import cupy
 import numpy as np
 
 from typing import Tuple

--- a/deeptrack/benchmarks/test_image.py
+++ b/deeptrack/benchmarks/test_image.py
@@ -4,7 +4,7 @@ import itertools
 import deeptrack as dt
 import pytest
 import itertools
-import cupy as cp
+from deeptrack.backend._config import cupy as cp
 
 u = dt.units
 

--- a/deeptrack/image.py
+++ b/deeptrack/image.py
@@ -16,26 +16,14 @@ pad_image_to_fft(image: Image, axes = (0, 1))
     Transforms.
 """
 
-import warnings
-import cupy
 import numpy as np
-import numpy.lib.mixins
 import operator as ops
 from tensorflow import Tensor
 import tensorflow
 from .backend.tensorflow_bindings import TENSORFLOW_BINDINGS
+import numpy as np
 
-
-CUPY_INSTALLED = False
-try:
-    import cupy as cp
-
-    CUPY_INSTALLED = True
-except Exception:
-    CUPY_INSTALLED = False
-    warnings.warn(
-        "cupy not installed. GPU-accelerated simulations will not be possible"
-    )
+from .backend._config import cupy
 
 
 def _binary_method(op):
@@ -324,7 +312,8 @@ class Image:
         return self
 
     def to_numpy(self):
-
+        if isinstance(self._value, np.ndarray):
+            return self
         if isinstance(self._value, cupy.ndarray):
             return Image(self._value.get(), copy=False).merge_properties_from(self)
         if isinstance(self._value, tensorflow.Tensor):
@@ -413,8 +402,6 @@ def strip(v):
     return v
 
 
-
-
 def coerce(images):
     images = [Image(image, copy=False) for image in images]
 
@@ -466,6 +453,6 @@ def maybe_cupy(array):
     from . import config
 
     if config.gpu_enabled:
-        return cp.array(array)
+        return cupy.array(array)
 
     return array

--- a/deeptrack/optics.py
+++ b/deeptrack/optics.py
@@ -15,7 +15,7 @@ Brightfield
     Images coherently illuminated samples.
 """
 
-import cupy
+
 from pint.quantity import Quantity
 from deeptrack.backend.units import ConversionTable
 from deeptrack.properties import propagate_data_to_dependencies
@@ -23,7 +23,7 @@ import numpy as np
 from .features import DummyFeature, Feature, StructuralFeature
 from .image import Image, pad_image_to_fft, maybe_cupy
 from .types import ArrayLike, PropertyLike
-
+from .backend._config import cupy
 from scipy.ndimage import convolve
 
 from . import units as u
@@ -221,7 +221,7 @@ class Optics(Feature):
         )
 
         try:
-            np.nan_to_num(z_shift, False, 0, 0, 0)
+            z_shift = np.nan_to_num(z_shift, False, 0, 0, 0)
         except TypeError:
             np.nan_to_num(z_shift, z_shift)
 

--- a/deeptrack/test/test_elementwise.py
+++ b/deeptrack/test/test_elementwise.py
@@ -12,7 +12,8 @@ from numpy.testing._private.utils import assert_almost_equal
 from .. import elementwise, features, Image
 
 import numpy as np
-import cupy as cp
+from deeptrack.backend._config import cupy as cp
+
 import numpy.testing
 import inspect
 
@@ -43,11 +44,9 @@ def grid_test_features(
 
             expected_result = expected_result_function(f_a_input)
 
-            if isinstance(output._value, cp.ndarray):
-                output = output.get()
+            output = np.array(output)
 
-            if isinstance(expected_result, cp.ndarray):
-                expected_result = expected_result.get()
+            expected_result = np.array(expected_result)
 
             if isinstance(output, list) and isinstance(expected_result, list):
                 [

--- a/deeptrack/test/test_features.py
+++ b/deeptrack/test/test_features.py
@@ -11,7 +11,6 @@ from numpy.testing._private.utils import assert_almost_equal
 
 from .. import features, Image, properties, utils
 
-from ..image import array
 
 import numpy as np
 import numpy.testing
@@ -58,13 +57,13 @@ def grid_test_features(
 
         if isinstance(output, list) and isinstance(expected_result, list):
             [
-                np.testing.assert_almost_equal(array(a), array(b))
+                np.testing.assert_almost_equal(np.array(a), np.array(b))
                 for a, b in zip(output, expected_result)
             ]
 
         else:
             is_equal = np.array_equal(
-                array(output), array(expected_result), equal_nan=True
+                np.array(output), np.array(expected_result), equal_nan=True
             )
 
             tester.failIf(


### PR DESCRIPTION
Ensure that deeptrack runs smoothly without cupy installed. Defers calls to cupy to numpy in case it is not installed.