### PR TITLE
Add resolve arguments to property-list

### DIFF
--- a/deeptrack/features.py
+++ b/deeptrack/features.py
@@ -212,6 +212,9 @@ class Feature(DeepTrackNode):
 
         for index, image in enumerate(new_list):
 
+            if self.arguments:
+                image.append(self.arguments.properties())
+
             image.append(feature_input)
 
         # Merge input and new_list


### PR DESCRIPTION
If arguments were used with bind_arguments, these arguments are now passed to the list of properties of the image. This makes it easier to access specific properties after-the-fact.