### PR TITLE
Implement rudimentary citation system

### DIFF
--- a/deeptrack/backend/citations.py
+++ b/deeptrack/backend/citations.py
@@ -1,0 +1,35 @@
+deeptrack_bibtex = """
+@article{Midtvet2021DeepTrack,
+    author  = {Midtvedt,Benjamin  and 
+               Helgadottir,Saga  and 
+               Argun,Aykut  and 
+               Pineda,Jesús  and 
+               Midtvedt,Daniel  and 
+               Volpe,Giovanni},
+    title   = {Quantitative digital microscopy with deep learning},
+    journal = {Applied Physics Reviews},
+    volume  = {8},
+    number  = {1},
+    pages   = {011310},
+    year    = {2021},
+    doi     = {10.1063/5.0034891}
+}
+"""
+
+unet_bibtex = """
+@article{DBLP:journals/corr/RonnebergerFB15,
+  author    = {Olaf Ronneberger and
+               Philipp Fischer and
+               Thomas Brox},
+  title     = {U-Net: Convolutional Networks for Biomedical Image Segmentation},
+  journal   = {CoRR},
+  volume    = {abs/1505.04597},
+  year      = {2015},
+  url       = {http://arxiv.org/abs/1505.04597},
+  archivePrefix = {arXiv},
+  eprint    = {1505.04597},
+  timestamp = {Mon, 13 Aug 2018 16:46:52 +0200},
+  biburl    = {https://dblp.org/rec/journals/corr/RonnebergerFB15.bib},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+"""

--- a/deeptrack/backend/core.py
+++ b/deeptrack/backend/core.py
@@ -4,6 +4,7 @@ import numpy as np
 import operator
 
 from .. import utils, image
+from .citations import deeptrack_bibtex
 
 
 class DeepTrackDataObject:
@@ -134,6 +135,8 @@ class DeepTrackNode:
 
     __nonelike_default = object()
 
+    citations = {deeptrack_bibtex}
+
     def __init__(self, action=__nonelike_default, **kwargs):
         self.data = DeepTrackDataList()
         self.children = []
@@ -247,6 +250,13 @@ class DeepTrackNode:
 
         for dependency in self.dependencies:
             yield from dependency.recurse_dependencies(memory=memory)
+
+    def get_citations(self):
+        cites = self.citations
+        for dep in self.recurse_dependencies():
+            cites.union(dep.citations)
+
+        return cites
 
     def __call__(self, replicate_index=None):
 

--- a/deeptrack/models/convolutional.py
+++ b/deeptrack/models/convolutional.py
@@ -1,7 +1,8 @@
-from .utils import as_KerasModel
-
-from .layers import as_block
 from tensorflow.keras import layers, models
+
+from ..backend.citations import unet_bibtex
+from .layers import as_block
+from .utils import as_KerasModel, with_citation
 
 
 def center_crop(layer, target_layer):
@@ -124,6 +125,7 @@ def Convolutional(
 convolutional = Convolutional
 
 
+@with_citation(unet_bibtex)
 @as_KerasModel
 def UNet(
     input_shape=(None, None, 1),
@@ -218,7 +220,7 @@ def UNet(
 
         layer = upsampling_block(conv_layer_dimension)(layer)
 
-        concat_layer = center_crop(concat_layer, layer)
+        # concat_layer = center_crop(concat_layer, layer) Not currently working
 
         layer = layers.Concatenate(axis=-1)([layer, concat_layer])
 

--- a/deeptrack/models/utils.py
+++ b/deeptrack/models/utils.py
@@ -35,6 +35,22 @@ def load_model(filepath, custom_objects=None, compile=True, options=None):
     model = KerasModel(model, compile=False)
 
 
+def with_citation(citation):
+    def wrapper(func):
+        @wraps(func)
+        def inner(*args, **kwargs):
+            res = func(*args, **kwargs)
+            assert isinstance(
+                res, features.Feature
+            ), "Wrapped model is not a deeptrack object. Did you forget @as_KerasModel?"
+            res.citations = {*res.citations, citation}
+            return res
+
+        return inner
+
+    return wrapper
+
+
 def as_KerasModel(func):
     @wraps(func)
     def inner(*args, **kwargs):


### PR DESCRIPTION
Implements a recursive way of getting relevant citations for any deeptrack object. To add ones own citation, the following syntax is suggested:

```py
class MyDeepTrackObject(ParentDeepTrackObject):
    citations = {*ParentDeepTrackObject.citations, my_citation}
    ...
```

Where ParentDeepTrackObject is any deeptrack object (such as Feature or KerasModel).

For function-wrapped initialisers (How many network architectures are implemented currently), we provide the decorator `@with_citation`. Example is provided for the unet:

```py
@with_citation(unet_bibtex)
@as_KerasModel
def UNet():
    ...
```

Currently, the bibtex is not parsed in any way, and no validation of the correctness of the grammar is provided. I propose that such additions are to be implemented in the future if deemed relevant.

To recursively retrieve all citations of a deeptrack object (and its dependencies), we provide the utility method `obj.get_citations()`. This returns a set of unique citations that can be iterated over and printed:

```py 
for citation in some_pipeline.get_citations():
    print(citation)
```