### PR TITLE
Jp/rev magik

### DIFF
--- a/deeptrack/models/gnns/layers.py
+++ b/deeptrack/models/gnns/layers.py
@@ -9,10 +9,9 @@ from ..layers import (
 from ..utils import as_activation, as_normalization, single_layer_call, GELU
 
 
-class FGNN(tf.keras.layers.Layer):
+class MPN(tf.keras.layers.Layer):
     """
-    Fingerprinting Graph Layer.
-
+    Message-passing Graph Layer.
     Parameters
     ----------
     filters : int
@@ -23,10 +22,8 @@ class FGNN(tf.keras.layers.Layer):
         Normalization function of the layer. See keras and tfa docs for accepted strings.
     random_edge_dropout : float, optional
         Random edge dropout.
-    use_gates : bool, optional
-        Whether to use gated self-attention layers as update layer. Defaults to True.
-    att_layer_kwargs : dict, optional
-        Keyword arguments for the self-attention layer.
+    combine_layer : layer, optional
+        Layer to combine node features and aggregated messages.
     norm_kwargs : dict
         Arguments for the normalization function.
     kwargs : dict
@@ -39,28 +36,14 @@ class FGNN(tf.keras.layers.Layer):
         activation=GELU,
         normalization="LayerNormalization",
         random_edge_dropout=False,
-        use_gates=True,
-        att_layer_kwargs={},
+        combine_layer=tf.keras.layers.Lambda(lambda x: tf.concat(x, axis=-1)),
         norm_kwargs={},
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.filters = filters
         self.random_edge_dropout = random_edge_dropout
-
-        _multi_head_att_layer = (
-            MultiHeadGatedSelfAttention
-            if use_gates
-            else MultiHeadSelfAttention
-        )
-        # node update layer
-        self.update_layer = tf.keras.Sequential(
-            [
-                _multi_head_att_layer(**att_layer_kwargs),
-                as_activation(activation),
-                as_normalization(normalization)(**norm_kwargs),
-            ]
-        )
+        self.combine_layer = combine_layer
 
         # message layer
         self.message_layer = tf.keras.Sequential(
@@ -71,8 +54,28 @@ class FGNN(tf.keras.layers.Layer):
             ]
         )
 
+        # node update layers
+        self.update_layer = layers.Dense(self.filters)
+        self.update_norm = tf.keras.Sequential(
+            [
+                as_activation(activation),
+                as_normalization(normalization)(**norm_kwargs),
+            ]
+        )
+
+    def nodes_handler(self, nodes):
+        return nodes, None
+
+    def update_node_features(self, nodes, aggregated, learnable_embs, edges):
+        Combined = self.combine_layer([nodes, aggregated])
+        updated_nodes = self.update_norm(self.update_layer(Combined))
+        return updated_nodes
+
     def call(self, inputs):
         nodes, edge_features, edges, edge_weights, edge_dropout = inputs
+
+        # Handles node features according to the implementation
+        nodes, learnable_embs = self.nodes_handler(nodes)
 
         number_of_nodes = tf.shape(nodes)[1]
         number_of_edges = tf.shape(edges)[1]
@@ -128,8 +131,9 @@ class FGNN(tf.keras.layers.Layer):
         )
 
         # Update node features, (nOfnode, filters)
-        Combined = [nodes, aggregated]
-        updated_nodes = self.update_layer(Combined)
+        updated_nodes = self.update_node_features(
+            nodes, aggregated, learnable_embs, edges
+        )
 
         return (
             updated_nodes,
@@ -140,18 +144,132 @@ class FGNN(tf.keras.layers.Layer):
         )
 
 
-@register("FGNN")
-def FGNNlayer(
+@register("MPN")
+def MPNLayer(
+    filters,
     activation=GELU,
     normalization="LayerNormalization",
-    random_edge_dropout=False,
-    use_gates=True,
-    att_layer_kwargs={},
     norm_kwargs={},
     **kwargs,
 ):
-    """Fingerprinting Graph Layer.
+    """
+    Message-passing Graph Layer.
+    Parameters
+    ----------
+    filters : int
+        Number of filters.
+    activation : str or activation function or layer
+        Activation function of the layer. See keras docs for accepted strings.
+    normalization : str or normalization function or layer
+        Normalization function of the layer. See keras and tfa docs for accepted strings.
+    random_edge_dropout : float, optional
+        Random edge dropout.
+    combine_layer : layer, optional
+        Layer to combine node features and aggregated messages.
+    norm_kwargs : dict
+        Arguments for the normalization function.
+    kwargs : dict
+        Additional arguments.
+    """
 
+    def Layer(filters, **kwargs_inner):
+        kwargs_inner.update(kwargs)
+        layer = MPN(
+            filters,
+            activation=activation,
+            normalization=normalization,
+            norm_kwargs=norm_kwargs,
+            **kwargs,
+        )
+        return lambda x: single_layer_call(x, layer, None, None, {})
+
+    return Layer
+
+
+class GRUMPN(MPN):
+    """
+    GRU Graph Layer.
+    Parameters
+    ----------
+    filters : int
+        Number of filters.
+    activation : str or activation function or layer
+        Activation function of the layer. See keras docs for accepted strings.
+    normalization : str or normalization function or layer
+        Normalization function of the layer. See keras and tfa docs for accepted strings.
+    random_edge_dropout : float, optional
+        Random edge dropout.
+    combine_layer : layer, optional
+        Layer to combine node features and aggregated messages.
+    norm_kwargs : dict
+        Arguments for the normalization function.
+    kwargs : dict
+        Additional arguments.
+    """
+
+    def __init__(
+        self,
+        filters,
+        **kwargs,
+    ):
+        super().__init__(filters, **kwargs)
+
+        # node update layer
+        self.update_layer = layers.GRU(filters, time_major=True)
+
+    def update_node_features(self, nodes, aggregated, learnable_embs, edges):
+        Combined = tf.reshape(
+            tf.stack([nodes, aggregated], axis=0), (2, -1, nodes.shape[-1])
+        )
+        updated_nodes = self.update_layer(Combined)
+        return tf.reshape(updated_nodes, shape=tf.shape(nodes))
+
+
+@register("GRUMPN")
+def GRUMPNLayer(
+    filters,
+    activation=GELU,
+    normalization="LayerNormalization",
+    norm_kwargs={},
+    **kwargs,
+):
+    """
+    GRU Graph Layer.
+    Parameters
+    ----------
+    filters : int
+        Number of filters.
+    activation : str or activation function or layer
+        Activation function of the layer. See keras docs for accepted strings.
+    normalization : str or normalization function or layer
+        Normalization function of the layer. See keras and tfa docs for accepted strings.
+    random_edge_dropout : float, optional
+        Random edge dropout.
+    combine_layer : layer, optional
+        Layer to combine node features and aggregated messages.
+    norm_kwargs : dict
+        Arguments for the normalization function.
+    kwargs : dict
+        Additional arguments.
+    """
+
+    def Layer(filters, **kwargs_inner):
+        kwargs_inner.update(kwargs)
+        layer = GRUMPN(
+            filters,
+            activation=activation,
+            normalization=normalization,
+            norm_kwargs=norm_kwargs,
+            **kwargs,
+        )
+        return lambda x: single_layer_call(x, layer, None, None, {})
+
+    return Layer
+
+
+class FGNN(MPN):
+    """
+    Fingerprinting Graph Layer.
     Parameters
     ----------
     filters : int
@@ -166,6 +284,77 @@ def FGNNlayer(
         Whether to use gated self-attention layers as update layer. Defaults to True.
     att_layer_kwargs : dict, optional
         Keyword arguments for the self-attention layer.
+    combine_layer : layer, optional
+        Layer to combine node features and aggregated messages.
+    norm_kwargs : dict
+        Arguments for the normalization function.
+    kwargs : dict
+        Additional arguments.
+    """
+
+    def __init__(
+        self,
+        filters,
+        activation=GELU,
+        normalization="LayerNormalization",
+        use_gates=True,
+        att_layer_kwargs={},
+        combine_layer=layers.Layer(),
+        norm_kwargs={},
+        **kwargs,
+    ):
+        super().__init__(
+            filters,
+            activation=activation,
+            normalization=normalization,
+            combine_layer=combine_layer,
+            norm_kwargs=norm_kwargs,
+            **kwargs,
+        )
+
+        multi_head_att_layer = (
+            MultiHeadGatedSelfAttention
+            if use_gates
+            else MultiHeadSelfAttention
+        )
+
+        # node update layer
+        self.update_layer = multi_head_att_layer(**att_layer_kwargs)
+        self.update_norm = tf.keras.Sequential(
+            [
+                as_activation(activation),
+                as_normalization(normalization)(**norm_kwargs),
+            ]
+        )
+
+
+@register("FGNN")
+def FGNNlayer(
+    activation=GELU,
+    normalization="LayerNormalization",
+    use_gates=True,
+    att_layer_kwargs={},
+    norm_kwargs={},
+    **kwargs,
+):
+    """
+    Fingerprinting Graph Layer.
+    Parameters
+    ----------
+    filters : int
+        Number of filters.
+    activation : str or activation function or layer
+        Activation function of the layer. See keras docs for accepted strings.
+    normalization : str or normalization function or layer
+        Normalization function of the layer. See keras and tfa docs for accepted strings.
+    random_edge_dropout : float, optional
+        Random edge dropout.
+    use_gates : bool, optional
+        Whether to use gated self-attention layers as update layer. Defaults to True.
+    att_layer_kwargs : dict, optional
+        Keyword arguments for the self-attention layer.
+    combine_layer : layer, optional
+        Layer to combine node features and aggregated messages.
     norm_kwargs : dict
         Arguments for the normalization function.
     kwargs : dict
@@ -176,12 +365,11 @@ def FGNNlayer(
         kwargs_inner.update(kwargs)
         layer = FGNN(
             filters,
-            activation,
-            normalization,
-            random_edge_dropout,
-            use_gates,
-            att_layer_kwargs,
-            norm_kwargs,
+            activation=activation,
+            normalization=normalization,
+            use_gates=use_gates,
+            att_layer_kwargs=att_layer_kwargs,
+            norm_kwargs=norm_kwargs,
             **kwargs_inner,
         )
         return lambda x: single_layer_call(x, layer, None, None, {})
@@ -192,7 +380,122 @@ def FGNNlayer(
 class ClassTokenFGNN(FGNN):
     """
     Fingerprinting Graph Layer with Class Token.
+    Parameters
+    ----------
+    filters : int
+        Number of filters.
+    activation : str or activation function or layer
+        Activation function of the layer. See keras docs for accepted strings.
+    normalization : str or normalization function or layer
+        Normalization function of the layer. See keras and tfa docs for accepted strings.
+    random_edge_dropout : float, optional
+        Random edge dropout.
+    use_gates : bool, optional
+        Whether to use gated self-attention layers as update layer. Defaults to True.
+    dense_to_combine : bool, optional
+        Whether to use a dense layer to combine node features and aggregated messages. Defaults to True.
+    att_layer_kwargs : dict, optional
+        Keyword arguments for the self-attention layer.
+    combine_layer : layer, optional
+        Layer to combine node features and aggregated messages.
+    norm_kwargs : dict
+        Arguments for the normalization function.
+    kwargs : dict
+        Additional arguments.
+    """
 
+    def __init__(
+        self,
+        filters,
+        combine_layer=tf.keras.layers.Lambda(lambda x: tf.concat(x, axis=-1)),
+        dense_to_combine=True,
+        **kwargs,
+    ):
+
+        super().__init__(
+            filters,
+            combine_layer=combine_layer,
+            **kwargs,
+        )
+
+        self.dense_to_combine = (
+            layers.Dense(self.filters) if dense_to_combine else layers.Layer()
+        )
+
+        self.process_class_token = layers.Dense(self.filters)
+
+    def nodes_handler(self, nodes):
+        return nodes[:, 1:, :], nodes[:, 0:1, :]
+
+    def update_node_features(self, nodes, aggregated, learnable_embs, edges):
+        Combined = tf.concat(
+            [
+                self.process_class_token(learnable_embs),
+                self.dense_to_combine(self.combine_layer([nodes, aggregated])),
+            ],
+            axis=1,
+        )
+        updated_nodes = self.update_norm(self.update_layer(Combined))
+        return updated_nodes
+
+
+@register("CTFGNN")
+def ClassTokenFGNNlayer(
+    activation=GELU,
+    normalization="LayerNormalization",
+    use_gates=True,
+    att_layer_kwargs={},
+    norm_kwargs={},
+    **kwargs,
+):
+    """
+    Fingerprinting Graph Layer with Class Token.
+    Parameters
+    ----------
+    filters : int
+        Number of filters.
+    activation : str or activation function or layer
+        Activation function of the layer. See keras docs for accepted strings.
+    normalization : str or normalization function or layer
+        Normalization function of the layer. See keras and tfa docs for accepted strings.
+    random_edge_dropout : float, optional
+        Random edge dropout.
+    use_gates : bool, optional
+        Whether to use gated self-attention layers as update layer. Defaults to True.
+    dense_to_combine : bool, optional
+        Whether to use a dense layer to combine node features and aggregated messages. Defaults to True.
+    att_layer_kwargs : dict, optional
+        Keyword arguments for the self-attention layer.
+    combine_layer : layer, optional
+        Layer to combine node features and aggregated messages.
+    norm_kwargs : dict
+        Arguments for the normalization function.
+    kwargs : dict
+        Additional arguments.
+    """
+
+    def Layer(filters, **kwargs_inner):
+        kwargs_inner.update(kwargs)
+        layer = ClassTokenFGNN(
+            filters,
+            activation=activation,
+            normalization=normalization,
+            use_gates=use_gates,
+            att_layer_kwargs=att_layer_kwargs,
+            norm_kwargs=norm_kwargs,
+            **kwargs_inner,
+        )
+        return lambda x: single_layer_call(x, layer, None, None, {})
+
+    return Layer
+
+
+class MaskedFGNN(FGNN):
+    """
+    Fingerprinting Graph Layer with Masked Attention.
+    Parameters
+    ----------
+    filters : int
     Parameters
     ----------
     filters : int
@@ -207,121 +510,49 @@ class ClassTokenFGNN(FGNN):
         Whether to use gated self-attention layers as update layer. Defaults to True.
     att_layer_kwargs : dict, optional
         Keyword arguments for the self-attention layer.
+    combine_layer : layer, optional
+        Layer to combine node features and aggregated messages.
     norm_kwargs : dict
         Arguments for the normalization function.
     kwargs : dict
         Additional arguments.
     """
 
-    def build(self, input_shape):
-        super().build(input_shape)
-        self.combine_layer = tf.keras.Sequential(
-            [
-                tf.keras.layers.Lambda(lambda x: tf.concat(x, axis=-1)),
-                layers.Dense(self.filters),
-            ]
+    def update_node_features(self, nodes, aggregated, learnable_embs, edges):
+        Combined = self.combine_layer([nodes, aggregated])
+        updated_nodes = self.update_norm(
+            self.update_layer(Combined, edges=edges)
         )
-
-    def call(self, inputs):
-        nodes, edge_features, edges, edge_weights, edge_dropout = inputs
-
-        # Split nodes and class-token embeddings
-        class_token, nodes = nodes[:, 0:1, :], nodes[:, 1:, :]
-
-        number_of_nodes = tf.shape(nodes)[1]
-        number_of_edges = tf.shape(edges)[1]
-        number_of_node_features = nodes.shape[-1]
-
-        batch_size = tf.shape(nodes)[0]
-
-        # Get neighbors node features, shape = (batch, nOfedges, 2, nOffeatures)
-        message_inputs = tf.gather(nodes, edges, batch_dims=1)
-
-        # Concatenate nodes features with edge features,
-        # shape = (batch, nOfedges, 2*nOffeatures + nOffedgefeatures)
-        messages = tf.reshape(
-            message_inputs,
-            (
-                batch_size,
-                number_of_edges,
-                2 * number_of_node_features,
-            ),
-        )
-        reshaped = tf.concat(
-            [
-                messages,
-                edge_features,
-            ],
-            -1,
-        )
-
-        # Compute messages/update edges, shape = (batch, nOfedges, filters)
-        messages = self.message_layer(reshaped)
-
-        # Compute weighted messages
-        # shape = (batch, nOfedges, filters)
-        weighted_messages = messages * edge_weights
-
-        # Merge repeated edges, shape = (batch, nOfedges (before augmentation), filters)
-        def aggregate(_, x):
-            message, edge, dropout = x
-
-            merged_edges = tf.math.unsorted_segment_sum(
-                message * dropout[:, 1:2],
-                edge[:, 1],
-                number_of_nodes,
-            )
-
-            return merged_edges
-
-        # Aggregate messages, shape = (batch, nOfnodes, filters)
-        aggregated = tf.scan(
-            aggregate,
-            (weighted_messages, edges, edge_dropout),
-            initializer=tf.zeros((number_of_nodes, number_of_node_features)),
-        )
-
-        # Update node features, (nOfnode, filters)
-        Combined = tf.concat(
-            [class_token, self.combine_layer([nodes, aggregated])], axis=1
-        )
-        updated_nodes = self.update_layer(Combined)
-
-        return (
-            updated_nodes,
-            weighted_messages,
-            edges,
-            edge_weights,
-            edge_dropout,
-        )
+        return updated_nodes
 
 
-@register("CTFGNN")
-def ClassTokenFGNNlayer(
+@register("MaskedFGNN")
+def MaskedFGNNlayer(
     activation=GELU,
     normalization="LayerNormalization",
-    random_edge_dropout=False,
     use_gates=True,
     att_layer_kwargs={},
     norm_kwargs={},
     **kwargs,
 ):
-    """Fingerprinting Graph Layer with Class Token.
-    
+    """
+    Fingerprinting Graph Layer with Masked Attention.
     Parameters
     ----------
-    number_of_heads : int
-        Number of attention heads.
-    message_layer : str or callable
-        Message layer.
-    update_layer : str or callable
-        Update layer.
-    random_edge_dropout : float, optional
-        Random edge dropout.
+    filters : int
+        Number of filters.
     activation : str or activation function or layer
         Activation function of the layer. See keras docs for accepted strings.
     normalization : str or normalization function or layer
         Normalization function of the layer. See keras and tfa docs for accepted strings.
+    random_edge_dropout : float, optional
+        Random edge dropout.
+    use_gates : bool, optional
+        Whether to use gated self-attention layers as update layer. Defaults to True.
+    att_layer_kwargs : dict, optional
+        Keyword arguments for the self-attention layer.
+    combine_layer : layer, optional
+        Layer to combine node features and aggregated messages.
     norm_kwargs : dict
         Arguments for the normalization function.
     kwargs : dict
@@ -330,15 +561,150 @@ def ClassTokenFGNNlayer(
 
     def Layer(filters, **kwargs_inner):
         kwargs_inner.update(kwargs)
-        layer = ClassTokenFGNN(
+        layer = MaskedFGNN(
             filters,
+            activation=activation,
+            normalization=normalization,
+            use_gates=use_gates,
+            att_layer_kwargs=att_layer_kwargs,
+            norm_kwargs=norm_kwargs,
+            **kwargs_inner,
+        )
+        return lambda x: single_layer_call(x, layer, None, None, {})
+
+    return Layer
+
+
+class GraphTransformer(tf.keras.layers.Layer):
+    """Graph Transformer.
+    Parameters
+    ----------
+    fwd_mlp_dim : int
+        Dimension of the forward MLP.
+    number_of_heads : int
+        Number of attention heads.
+    activation : str or activation function or layer
+        Activation function of the layer. See keras docs for accepted strings.
+    normalization : str or normalization function or layer
+        Normalization function of the layer. See keras and tfa docs for accepted strings.
+    use_bias: bool, optional
+        Whether to use bias in the dense layers of the attention layers. Defaults to False.
+    dropout : float
+        Dropout rate.
+    norm_kwargs : dict
+        Arguments for the normalization function.
+    kwargs : dict
+        Additional arguments.
+    """
+
+    def __init__(
+        self,
+        fwd_mlp_dim,
+        number_of_heads=12,
+        activation=GELU,
+        normalization="LayerNormalization",
+        use_bias=True,
+        clip_scores_by_value=(-5.0, 5.0),
+        dropout=0.0,
+        norm_kwargs={},
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.number_of_heads = number_of_heads
+        self.use_bias = use_bias
+
+        self.fwd_mlp_dim = fwd_mlp_dim
+        self.dropout = dropout
+
+        self.activation = activation
+        self.normalization = normalization
+
+        self.clip_scores_by_value = clip_scores_by_value
+
+        self.MaskedMultiHeadAttLayer = MultiHeadSelfAttention(
+            number_of_heads=self.number_of_heads,
+            use_bias=self.use_bias,
+            name="MaskedMultiHeadAttLayer",
+            clip_scores_by_value=self.clip_scores_by_value,
+        )
+        self.norm_0, self.norm_1 = (
+            as_normalization(normalization)(**norm_kwargs),
+            as_normalization(normalization)(**norm_kwargs),
+        )
+        self.dropout_layer = tf.keras.layers.Dropout(self.dropout)
+
+    def build(self, input_shape):
+        input_shape, *_ = input_shape
+
+        self.feed_forward_layer = tf.keras.Sequential(
+            [
+                layers.Dense(
+                    self.fwd_mlp_dim,
+                    name=f"{self.name}/Dense_0",
+                ),
+                as_activation(self.activation),
+                layers.Dropout(self.dropout),
+                layers.Dense(input_shape[-1], name=f"{self.name}/Dense_1"),
+                layers.Dropout(self.dropout),
+            ],
+            name="feed_forward",
+        )
+
+    def call(self, inputs, training):
+        nodes, edges = inputs
+
+        x = self.MaskedMultiHeadAttLayer(nodes, edges=edges)
+        x = self.dropout_layer(x, training=training)
+        x = self.norm_0(nodes + x)
+
+        y = self.feed_forward_layer(x)
+        return self.norm_1(x + y), edges
+
+
+@register("GraphTransformerLayer")
+def GraphTransformerLayer(
+    number_of_heads=6,
+    activation=GELU,
+    normalization="LayerNormalization",
+    use_bias=True,
+    clip_scores_by_value=(-5.0, 5.0),
+    dropout=0.0,
+    norm_kwargs={},
+    **kwargs,
+):
+    """Graph Transformer Layer.
+    Parameters
+    ----------
+    number_of_heads : int
+        Number of attention heads.
+    dropout : float
+        Dropout rate.
+    activation : str or activation function or layer
+        Activation function of the layer. See keras docs for accepted strings.
+    normalization : str or normalization function or layer
+        Normalization function of the layer. See keras and tfa docs for accepted strings.
+    use_gates : bool, optional
+        Whether to use gated self-attention layers as update layer. Defaults to False.
+    use_bias: bool, optional
+        Whether to use bias in the dense layers of the attention layers. Defaults to True.
+    norm_kwargs : dict
+        Arguments for the normalization function.
+    kwargs : dict
+        Additional arguments.
+    """
+
+    def Layer(filters, **kwargs_inner):
+        kwargs_inner.update(kwargs)
+        layer = GraphTransformer(
+            filters,
+            number_of_heads,
             activation,
             normalization,
-            random_edge_dropout,
-            use_gates,
-            att_layer_kwargs,
+            use_bias,
+            clip_scores_by_value,
+            dropout,
             norm_kwargs,
-            **kwargs_inner,
+            **kwargs,
         )
         return lambda x: single_layer_call(x, layer, None, None, {})
 

--- a/deeptrack/models/gnns/layers.py
+++ b/deeptrack/models/gnns/layers.py
@@ -146,7 +146,6 @@ class MPN(tf.keras.layers.Layer):
 
 @register("MPN")
 def MPNLayer(
-    filters,
     activation=GELU,
     normalization="LayerNormalization",
     norm_kwargs={},
@@ -227,7 +226,6 @@ class GRUMPN(MPN):
 
 @register("GRUMPN")
 def GRUMPNLayer(
-    filters,
     activation=GELU,
     normalization="LayerNormalization",
     norm_kwargs={},

--- a/deeptrack/models/gnns/models.py
+++ b/deeptrack/models/gnns/models.py
@@ -8,7 +8,9 @@ from ..embeddings import LearnableDistanceEmbedding
 
 class MAGIK(KerasModel):
     """
-    Message passing graph neural network.
+    MAGIK, a message-passing Graph Neural Network, to estimate the dynamical properties
+    of moving objects from time-lapse experiments. For more information about this model,
+    please refer to: https://arxiv.org/abs/2202.06355
 
     Parameters:
     -----------
@@ -29,7 +31,8 @@ class MAGIK(KerasModel):
     dense_block: str, keras.layers.Layer, or callable
         The dense block to use for the encoder and decoder.
     graph_block: str, keras.layers.Layer, or callable
-        The graph block to use for the graph blocks.
+        The graph block to use for the graph computation. See gnns.layers for available
+        graph blocks.
     output_type: str
         Type of output. Either "nodes", "edges", or "graph".
         If 'key' is not a supported output type, then the
@@ -160,8 +163,11 @@ class MAGIK(KerasModel):
 
 class CTMAGIK(KerasModel):
     """
-    Message passing graph neural network.
-    
+    CTMAGIK, a message-passing Graph Neural Network, to estimate system-level dynamical properties
+    of moving objects from time-lapse experiments. This model implements an extra learnable token
+    to aggregate global attributes from the whole graph. For more information about this model,
+    please refer to: https://arxiv.org/abs/2202.06355
+
     Parameters:
     -----------
     dense_layer_dimensions: list of ints
@@ -187,7 +193,8 @@ class CTMAGIK(KerasModel):
     dense_block: str, keras.layers.Layer, or callable
         The dense block to use for the encoder and decoder.
     graph_block: str, keras.layers.Layer, or callable
-        The graph block to use for the graph blocks.
+        The graph block to use for the graph computation. See gnns.layers for available
+        graph blocks.
     classtokens_block: str, keras.layers.Layer, or callable
         The embedding block to use for the class tokens.
     output_type: str
@@ -325,6 +332,169 @@ class CTMAGIK(KerasModel):
             activation=global_output_activation,
             name="global_prediction",
         )(cls_layer)
+
+        output_dict = {
+            "nodes": node_output,
+            "edges": edge_output,
+            "global": global_output,
+            "graph": [node_output, edge_output, global_output],
+        }
+        try:
+            outputs = output_dict[output_type]
+        except KeyError:
+            outputs = output_dict["graph"]
+
+        model = tf.keras.models.Model(
+            [node_features, edge_features, edges, edge_dropout],
+            outputs,
+        )
+
+        super().__init__(model, **kwargs)
+
+
+class MPNGNN(KerasModel):
+    """
+    Message-passing Graph Neural Network.
+
+    Parameters:
+    -----------
+    dense_layer_dimensions: list of ints
+        List of the number of units in each dense layer of the encoder and decoder. The
+        number of layers is inferred from the length of this list.
+    base_layer_dimensions: list of ints
+        List of the latent dimensions of the graph blocks. The number of layers is
+        inferred from the length of this list.
+    number_of_node_outputs: int
+        Number of output node features.
+    number_of_edge_outputs: int
+        Number of output edge features.
+    number_of_global_outputs: int
+        Number of output global features.
+    node_output_activation: str or activation function or layer
+        Activation function for the output node layer. See keras docs for accepted strings.
+    edge_output_activation: str or activation function or layer
+        Activation function for the output edge layer. See keras docs for accepted strings.
+    cls_layer_dimension: int
+        Number of units in the decoder layer for global features.
+    global_output_activation: str or activation function or layer
+        Activation function for the output global layer. See keras docs for accepted strings.
+    dense_block: str, keras.layers.Layer, or callable
+        The dense block to use for the encoder and decoder.
+    graph_block: str, keras.layers.Layer, or callable
+        The graph block to use for the graph computation. See gnns.layers for available
+        graph blocks.
+    readout_block: str, keras.layers.Layer, or callable
+        The readout block used to compute global features.
+    output_type: str
+        Type of output. Either "nodes", "edges", "global" or
+        "graph". If 'key' is not a supported output type, then
+        the model output will be the concatenation of the node,
+        edge, and global predictions.
+    kwargs: dict
+        Keyword arguments for the dense block.
+    Returns:
+    --------
+    tf.keras.Model
+        Keras model for the graph neural network.
+    """
+
+    def __init__(
+        self,
+        dense_layer_dimensions=(32, 64, 96),
+        base_layer_dimensions=(96, 96),
+        number_of_node_features=3,
+        number_of_edge_features=1,
+        number_of_node_outputs=1,
+        number_of_edge_outputs=1,
+        number_of_global_outputs=1,
+        node_output_activation=None,
+        edge_output_activation=None,
+        global_layer_dimension=64,
+        global_output_activation=None,
+        dense_block=DenseBlock(
+            activation=GELU,
+            normalization="LayerNormalization",
+        ),
+        graph_block="MPN",
+        readout_block=layers.Lambda(
+            lambda x: tf.math.reduce_sum(x, axis=1), name="global_readout"
+        ),
+        output_type="graph",
+        **kwargs
+    ):
+        dense_block = as_block(dense_block)
+        graph_block = as_block(graph_block)
+
+        node_features, edge_features, edges, edge_dropout = (
+            tf.keras.Input(shape=(None, number_of_node_features)),
+            tf.keras.Input(shape=(None, number_of_edge_features)),
+            tf.keras.Input(shape=(None, 2), dtype=tf.int32),
+            tf.keras.Input(shape=(None, 2)),
+        )
+
+        node_layer = node_features
+        edge_layer = edge_features
+
+        # Encoder for node and edge features
+        for dense_layer_number, dense_layer_dimension in zip(
+            range(len(dense_layer_dimensions)), dense_layer_dimensions
+        ):
+            node_layer = dense_block(
+                dense_layer_dimension,
+                name="node_ide" + str(dense_layer_number + 1),
+                **kwargs
+            )(node_layer)
+
+            edge_layer = dense_block(
+                dense_layer_dimension,
+                name="edge_ide" + str(dense_layer_number + 1),
+                **kwargs
+            )(edge_layer)
+
+        # Bottleneck path, graph blocks
+        layer = (
+            node_layer,
+            edge_layer,
+            edges,
+            tf.ones_like(edge_features[..., 0:1]),
+            edge_dropout,
+        )
+
+        for base_layer_number, base_layer_dimension in zip(
+            range(len(base_layer_dimensions)), base_layer_dimensions
+        ):
+            layer = graph_block(
+                base_layer_dimension,
+                name="graph_block_" + str(base_layer_number),
+            )(layer)
+
+        # Split nodes and edges
+        node_layer, edge_layer, *_ = layer
+
+        # Compute global features
+        global_layer = readout_block(node_layer)
+        global_layer = dense_block(
+            global_layer_dimension, name="cls_mlp", **kwargs
+        )(global_layer)
+
+        # Output layers
+        node_output = layers.Dense(
+            number_of_node_outputs,
+            activation=node_output_activation,
+            name="node_prediction",
+        )(node_layer)
+
+        edge_output = layers.Dense(
+            number_of_edge_outputs,
+            activation=edge_output_activation,
+            name="edge_prediction",
+        )(edge_layer)
+
+        global_output = layers.Dense(
+            number_of_global_outputs,
+            activation=global_output_activation,
+            name="global_prediction",
+        )(global_layer)
 
         output_dict = {
             "nodes": node_output,

--- a/deeptrack/models/layers.py
+++ b/deeptrack/models/layers.py
@@ -449,7 +449,7 @@ class MultiHeadSelfAttention(layers.Layer):
 
     def softmax(self, x, axis=-1):
         exp = tf.exp(x - tf.reduce_max(x, axis=axis, keepdims=True))
-        
+
         if self.clip_scores_by_value:
             exp = tf.clip_by_value(exp, *self.clip_scores_by_value)
 
@@ -560,7 +560,9 @@ class MultiHeadSelfAttention(layers.Layer):
 
 class MultiHeadGatedSelfAttention(MultiHeadSelfAttention):
     def build(self, input_shape):
-        """Build the layer."""
+        """
+        Build the layer.
+        """
         try:
             filters = input_shape[1][-1]
         except TypeError:
@@ -581,8 +583,8 @@ class MultiHeadGatedSelfAttention(MultiHeadSelfAttention):
         self.combine_dense = layers.Dense(filters)
 
     def compute_attention(self, x, **kwargs):
-        """Compute attention.
-
+        """
+        Compute attention.
         Parameters
         ----------
         x : tf.Tensor
@@ -607,7 +609,9 @@ class MultiHeadGatedSelfAttention(MultiHeadSelfAttention):
         gate = self.separate_heads(gate, batch_size)
 
         return (
-            self.SingleAttention(query, key, value, gate, **kwargs),
+            self.SingleAttention(
+                query, key, value, gate=gate, batch_size=batch_size, **kwargs
+            ),
             batch_size,
         )
 

--- a/deeptrack/models/layers.py
+++ b/deeptrack/models/layers.py
@@ -575,10 +575,12 @@ class MultiHeadGatedSelfAttention(MultiHeadSelfAttention):
         self.filters = filters
         self.projection_dim = filters // self.number_of_heads
 
-        self.query_dense = layers.Dense(filters)
-        self.key_dense = layers.Dense(filters)
-        self.value_dense = layers.Dense(filters)
-        self.gate_dense = layers.Dense(filters, activation="sigmoid")
+        self.query_dense = layers.Dense(filters, use_bias=self.use_bias)
+        self.key_dense = layers.Dense(filters, use_bias=self.use_bias)
+        self.value_dense = layers.Dense(filters, use_bias=self.use_bias)
+        self.gate_dense = layers.Dense(
+            filters, use_bias=self.use_bias, activation="sigmoid"
+        )
 
         self.combine_dense = layers.Dense(filters)
 

--- a/deeptrack/models/layers.py
+++ b/deeptrack/models/layers.py
@@ -622,7 +622,6 @@ class MultiHeadGatedSelfAttention(MultiHeadSelfAttention):
 def MultiHeadSelfAttentionLayer(
     number_of_heads=12,
     use_bias=True,
-    return_attention_weights=False,
     activation="relu",
     normalization="LayerNormalization",
     norm_kwargs={},
@@ -640,8 +639,6 @@ def MultiHeadSelfAttentionLayer(
         Number of attention heads.
     use_bias : bool
         Whether to use bias in the dense layers.
-    return_attention_weights : bool
-        Whether to return attention weights for visualization.
     clip_scores_by_value: tuple of float
         Clipping values for attention scores.
     activation : str or activation function or layer
@@ -657,7 +654,10 @@ def MultiHeadSelfAttentionLayer(
     def Layer(filters, **kwargs_inner):
         kwargs_inner.update(kwargs)
         layer = MultiHeadSelfAttention(
-            number_of_heads, use_bias, return_attention_weights, **kwargs_inner
+            number_of_heads,
+            use_bias,
+            return_attention_weights=False,
+            **kwargs_inner,
         )
         return lambda x: single_layer_call(
             x, layer, activation, normalization, norm_kwargs
@@ -670,7 +670,6 @@ def MultiHeadSelfAttentionLayer(
 def MultiHeadGatedSelfAttentionLayer(
     number_of_heads=12,
     use_bias=True,
-    return_attention_weights=False,
     activation="relu",
     normalization="LayerNormalization",
     norm_kwargs={},
@@ -688,8 +687,6 @@ def MultiHeadGatedSelfAttentionLayer(
         Number of attention heads.
     use_bias : bool
         Whether to use bias in the dense layers.
-    return_attention_weights : bool
-        Whether to return attention weights for visualization.
     clip_scores_by_value: tuple of float
         Clipping values for attention scores.
     activation : str or activation function or layer
@@ -705,7 +702,10 @@ def MultiHeadGatedSelfAttentionLayer(
     def Layer(filters, **kwargs_inner):
         kwargs_inner.update(kwargs)
         layer = MultiHeadGatedSelfAttention(
-            number_of_heads, use_bias, return_attention_weights, **kwargs_inner
+            number_of_heads,
+            use_bias,
+            return_attention_weights=False,
+            **kwargs_inner,
         )
         return lambda x: single_layer_call(
             x, layer, activation, normalization, norm_kwargs

--- a/deeptrack/models/layers.py
+++ b/deeptrack/models/layers.py
@@ -640,6 +640,8 @@ def MultiHeadSelfAttentionLayer(
         Whether to use bias in the dense layers.
     return_attention_weights : bool
         Whether to return attention weights for visualization.
+    clip_scores_by_value: tuple of float
+        Clipping values for attention scores.
     activation : str or activation function or layer
         Activation function of the layer. See keras docs for accepted strings.
     normalization : str or normalization function or layer
@@ -686,6 +688,8 @@ def MultiHeadGatedSelfAttentionLayer(
         Whether to use bias in the dense layers.
     return_attention_weights : bool
         Whether to return attention weights for visualization.
+    clip_scores_by_value: tuple of float
+        Clipping values for attention scores.
     activation : str or activation function or layer
         Activation function of the layer. See keras docs for accepted strings.
     normalization : str or normalization function or layer

--- a/deeptrack/models/layers.py
+++ b/deeptrack/models/layers.py
@@ -43,7 +43,9 @@ def as_block(x):
                 + ", ".join(BLOCKS.keys())
             )
     if isinstance(x, layers.Layer) or not callable(x):
-        raise TypeError("Layer block should be a function that returns a keras Layer.")
+        raise TypeError(
+            "Layer block should be a function that returns a keras Layer."
+        )
     else:
         return x
 
@@ -97,7 +99,9 @@ def ConvolutionalBlock(
 
 
 @register("dense")
-def DenseBlock(activation="relu", normalization=False, norm_kwargs={}, **kwargs):
+def DenseBlock(
+    activation="relu", normalization=False, norm_kwargs={}, **kwargs
+):
     """A single dense layer.
 
     Accepts arguments of keras.layers.Dense.
@@ -159,7 +163,10 @@ def PoolingBlock(
     def Layer(filters=None, **kwargs_inner):
         kwargs_inner.update(kwargs)
         layer = layers.MaxPool2D(
-            pool_size=pool_size, padding=padding, strides=strides, **kwargs_inner
+            pool_size=pool_size,
+            padding=padding,
+            strides=strides,
+            **kwargs_inner,
         )
         return lambda x: single_layer_call(
             x, layer, activation, normalization, norm_kwargs
@@ -318,7 +325,9 @@ def ResidualBlock(
         )
 
         def call(x):
-            y = single_layer_call(x, conv, activation, normalization, norm_kwargs)
+            y = single_layer_call(
+                x, conv, activation, normalization, norm_kwargs
+            )
             y = single_layer_call(y, conv2, None, normalization, norm_kwargs)
             y = layers.Add()([identity(x), y])
             if activation:
@@ -362,7 +371,6 @@ def Identity(activation=None, normalization=False, norm_kwargs={}, **kwargs):
 
 class MultiHeadSelfAttention(layers.Layer):
     """Multi-head self-attention layer.
-
     Parameters
     ----------
     number_of_heads : int
@@ -371,6 +379,8 @@ class MultiHeadSelfAttention(layers.Layer):
         Whether to use bias in attention layer.
     return_attention_weights : bool
         Whether to return the attention weights for visualization.
+    clip_scores_by_value: tuple of float (Optional)
+        Clipping values for attention scores.
     kwargs
         Other arguments for the keras.layers.Layer
     """
@@ -380,12 +390,14 @@ class MultiHeadSelfAttention(layers.Layer):
         number_of_heads=12,
         use_bias=True,
         return_attention_weights=False,
+        clip_scores_by_value: tuple = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.number_of_heads = number_of_heads
         self.use_bias = use_bias
         self.return_attention_weights = return_attention_weights
+        self.clip_scores_by_value = clip_scores_by_value
 
     def build(self, input_shape):
         try:
@@ -406,9 +418,48 @@ class MultiHeadSelfAttention(layers.Layer):
 
         self.combine_dense = layers.Dense(filters, use_bias=self.use_bias)
 
-    def SingleAttention(self, query, key, value, gate=None, **kwargs):
-        """Single attention layer.
+    def compute_attention_mask(self, x, edges, batch_size=None, **kwargs):
+        """
+        Computes the attention mask. The mask prevents
+        attention to certain positions.
+        Parameters
+        ----------
+        edges : tf.Tensor
+            The edges of the graph.
+        Returns
+        -------
+        tf.Tensor
+            The attention mask.
+        """
+        number_of_edges = tf.shape(edges)[1]
 
+        batch_dims = tf.range(batch_size)
+        batch_dims = tf.repeat(batch_dims, number_of_edges)
+        batch_dims = tf.reshape(
+            batch_dims, shape=(batch_size, number_of_edges, 1)
+        )
+        indices = tf.concat(
+            [batch_dims, tf.zeros_like(batch_dims), edges], axis=-1
+        )
+
+        mask = tf.tensor_scatter_nd_update(
+            x, indices, tf.ones((batch_size, number_of_edges))
+        )
+        return -10e9 * (1.0 - mask)
+
+    def softmax(self, x, axis=-1):
+        exp = tf.exp(x - tf.reduce_max(x, axis=axis, keepdims=True))
+        
+        if self.clip_scores_by_value:
+            exp = tf.clip_by_value(exp, *self.clip_scores_by_value)
+
+        return tf.math.divide(exp, tf.reduce_sum(exp, axis=-1, keepdims=True))
+
+    def SingleAttention(
+        self, query, key, value, gate=None, edges=None, **kwargs
+    ):
+        """
+        Single attention layer.
         Parameters
         ----------
         query : tf.Tensor
@@ -424,7 +475,14 @@ class MultiHeadSelfAttention(layers.Layer):
         dim_key = tf.cast(tf.shape(key)[-1], score.dtype)
         scaled_score = score / tf.math.sqrt(dim_key)
 
-        weights = tf.nn.softmax(scaled_score, axis=-1)
+        if edges is not None:
+            scaled_score += self.compute_attention_mask(
+                tf.zeros_like(scaled_score[:, 0:1]),
+                edges,
+                **kwargs,
+            )
+
+        weights = self.softmax(scaled_score, axis=-1)
         output = tf.matmul(weights, value)
 
         if gate is not None:
@@ -434,7 +492,6 @@ class MultiHeadSelfAttention(layers.Layer):
 
     def separate_heads(self, x, batch_size):
         """
-
         Parameters
         ----------
         x : tf.Tensor
@@ -444,12 +501,13 @@ class MultiHeadSelfAttention(layers.Layer):
         projection_dim : int
             Projection dimension.
         """
-        x = tf.reshape(x, (batch_size, -1, self.number_of_heads, self.projection_dim))
+        x = tf.reshape(
+            x, (batch_size, -1, self.number_of_heads, self.projection_dim)
+        )
         return tf.transpose(x, perm=[0, 2, 1, 3])
 
     def compute_attention(self, x, **kwargs):
         """
-
         Parameters
         ----------
         x : tf.Tensor
@@ -472,25 +530,30 @@ class MultiHeadSelfAttention(layers.Layer):
         value = self.separate_heads(value, batch_size)
 
         return (
-            self.SingleAttention(query, key, value, **kwargs),
+            self.SingleAttention(
+                query, key, value, batch_size=batch_size, **kwargs
+            ),
             batch_size,
         )
 
     def call(self, x, **kwargs):
         """
-
         Parameters
         ----------
         x : tuple of tf.Tensors
             Input tensors.
         """
-        (attention, weights), batch_size = self.compute_attention(x, **kwargs)
+        (attention, self.att_weights), batch_size = self.compute_attention(
+            x, **kwargs
+        )
         attention = tf.transpose(attention, perm=[0, 2, 1, 3])
-        concat_attention = tf.reshape(attention, (batch_size, -1, self.filters))
+        concat_attention = tf.reshape(
+            attention, (batch_size, -1, self.filters)
+        )
         output = self.combine_dense(concat_attention)
 
         if self.return_attention_weights:
-            return output, weights
+            return output, self.att_weights
         else:
             return output
 
@@ -691,7 +754,9 @@ class TransformerEncoder(tf.keras.layers.Layer):
         self.normalization = normalization
 
         self.MultiHeadAttLayer = (
-            MultiHeadGatedSelfAttention if self.use_gates else MultiHeadSelfAttention
+            MultiHeadGatedSelfAttention
+            if self.use_gates
+            else MultiHeadSelfAttention
         )(
             number_of_heads=self.number_of_heads,
             use_bias=self.use_bias,

--- a/deeptrack/test/test_layers.py
+++ b/deeptrack/test/test_layers.py
@@ -168,6 +168,11 @@ class TestModels(unittest.TestCase):
         model = makeMinimalModel(block(1), shape=(100, 96))
         self.assertEqual(model.layers[1].filters, 96)
 
+    def test_Multi_Head_Gated_Attention_bias(self):
+        block = layers.MultiHeadGatedSelfAttentionLayer(use_bias=False)
+        model = makeMinimalModel(block(1), shape=(100, 96))
+        self.assertFalse(model.layers[1].gate_dense.use_bias)
+
     def test_FGNN_layer(self):
         block = layers.FGNNlayer()
         model = makeMinimalModel(

--- a/deeptrack/test/test_models.py
+++ b/deeptrack/test/test_models.py
@@ -4,8 +4,10 @@ import sys
 
 import unittest
 
-from .. import models
+from .. import models, layers
 import numpy as np
+
+import tensorflow as tf
 
 
 class TestModels(unittest.TestCase):
@@ -109,6 +111,197 @@ class TestModels(unittest.TestCase):
         self.assertIsInstance(model, models.KerasModel)
 
         model.predict(np.zeros((1, 224, 224, 3)))
+
+    def test_MAGIK(self):
+        model = models.MAGIK(
+            dense_layer_dimensions=(
+                64,
+                96,
+            ),  # number of features in each dense encoder layer
+            base_layer_dimensions=(
+                96,
+                96,
+                96,
+            ),  # Latent dimension throughout the message passing layers
+            number_of_node_features=7,  # Number of node features in the graphs
+            number_of_edge_features=1,  # Number of edge features in the graphs
+            number_of_edge_outputs=1,  # Number of predicted features
+            edge_output_activation="sigmoid",  # Activation function for the output layer
+            output_type="edges",
+        )
+
+        self.assertIsInstance(model, models.KerasModel)
+
+        graph = (
+            tf.random.uniform((8, 10, 7)),  # Node features
+            tf.random.uniform((8, 50, 1)),  # Edge features
+            tf.random.uniform(
+                (8, 50, 2), minval=0, maxval=10, dtype=tf.int32
+            ),  # Edges
+            tf.random.uniform((8, 50, 2)),  # Edge dropouts
+        )
+        model.predict(graph)
+
+    def test_CTMAGIK(self):
+        model = models.CTMAGIK(
+            dense_layer_dimensions=(
+                32,
+                64,
+                96,
+            ),  # number of features in each dense encoder layer
+            base_layer_dimensions=(
+                96,
+                96,
+            ),  # Latent dimension throughout the message passing layers
+            number_of_node_features=7,  # Number of node features in the graphs
+            number_of_edge_features=1,  # Number of edge features in the graphs
+            number_of_global_outputs=1,  # Number of predicted features
+            global_output_activation="softmax",  # Activation function for the output layer
+            output_type="global",
+        )
+
+        self.assertIsInstance(model, models.KerasModel)
+
+        graph = (
+            tf.random.uniform((8, 10, 7)),  # Node features
+            tf.random.uniform((8, 50, 1)),  # Edge features
+            tf.random.uniform(
+                (8, 50, 2), minval=0, maxval=10, dtype=tf.int32
+            ),  # Edges
+            tf.random.uniform((8, 50, 2)),  # Edge dropouts
+        )
+        prediction = model.predict(graph)
+
+        self.assertEqual(prediction.shape, (8, 1))
+
+    def test_MAGIK_with_MaskedFGNN(self):
+        model = models.MAGIK(
+            dense_layer_dimensions=(
+                64,
+                96,
+            ),  # number of features in each dense encoder layer
+            base_layer_dimensions=(
+                96,
+                96,
+                96,
+            ),  # Latent dimension throughout the message passing layers
+            number_of_node_features=7,  # Number of node features in the graphs
+            number_of_edge_features=1,  # Number of edge features in the graphs
+            number_of_edge_outputs=1,  # Number of predicted features
+            edge_output_activation="sigmoid",  # Activation function for the output layer
+            output_type="edges",
+            graph_block="MaskedFGNN",
+        )
+
+        self.assertIsInstance(model, models.KerasModel)
+        self.assertIsInstance(model.layers[15], layers.MaskedFGNN)
+
+        graph = (
+            tf.random.uniform((8, 10, 7)),  # Node features
+            tf.random.uniform((8, 50, 1)),  # Edge features
+            tf.random.uniform(
+                (8, 50, 2), minval=0, maxval=10, dtype=tf.int32
+            ),  # Edges
+            tf.random.uniform((8, 50, 2)),  # Edge dropouts
+        )
+        model.predict(graph)
+
+    def test_MPGNN(self):
+        model = models.MPNGNN(
+            dense_layer_dimensions=(
+                64,
+                96,
+            ),  # number of features in each dense encoder layer
+            base_layer_dimensions=(
+                96,
+                96,
+                96,
+            ),  # Latent dimension throughout the message passing layers
+            number_of_node_features=7,  # Number of node features in the graphs
+            number_of_edge_features=1,  # Number of edge features in the graphs
+            number_of_edge_outputs=1,  # Number of predicted features
+            edge_output_activation="sigmoid",  # Activation function for the output layer
+            output_type="edges",
+        )
+
+        self.assertIsInstance(model, models.KerasModel)
+
+        graph = (
+            tf.random.uniform((8, 10, 7)),  # Node features
+            tf.random.uniform((8, 50, 1)),  # Edge features
+            tf.random.uniform(
+                (8, 50, 2), minval=0, maxval=10, dtype=tf.int32
+            ),  # Edges
+            tf.random.uniform((8, 50, 2)),  # Edge dropouts
+        )
+        model.predict(graph)
+
+    def test_MPGNN_readout(self):
+        model = models.MPNGNN(
+            dense_layer_dimensions=(
+                32,
+                64,
+                96,
+            ),  # number of features in each dense encoder layer
+            base_layer_dimensions=(
+                96,
+                96,
+            ),  # Latent dimension throughout the message passing layers
+            number_of_node_features=7,  # Number of node features in the graphs
+            number_of_edge_features=1,  # Number of edge features in the graphs
+            number_of_global_outputs=1,  # Number of predicted features
+            global_output_activation="softmax",  # Activation function for the output layer
+            output_type="global",
+            readout_block=tf.keras.layers.GlobalAveragePooling1D(),
+        )
+
+        self.assertIsInstance(model, models.KerasModel)
+        self.assertIsInstance(
+            model.layers[-4], tf.keras.layers.GlobalAveragePooling1D
+        )
+
+        graph = (
+            tf.random.uniform((8, 10, 7)),  # Node features
+            tf.random.uniform((8, 50, 1)),  # Edge features
+            tf.random.uniform(
+                (8, 50, 2), minval=0, maxval=10, dtype=tf.int32
+            ),  # Edges
+            tf.random.uniform((8, 50, 2)),  # Edge dropouts
+        )
+        prediction = model.predict(graph)
+
+        self.assertEqual(prediction.shape, (8, 1))
+
+    def test_GRU_MPGNN(self):
+        model = models.MPNGNN(
+            dense_layer_dimensions=(
+                64,
+                96,
+            ),  # number of features in each dense encoder layer
+            base_layer_dimensions=(
+                96,
+                96,
+                96,
+            ),  # Latent dimension throughout the message passing layers
+            number_of_node_features=7,  # Number of node features in the graphs
+            number_of_edge_features=1,  # Number of edge features in the graphs
+            number_of_edge_outputs=1,  # Number of predicted features
+            edge_output_activation="sigmoid",  # Activation function for the output layer
+            output_type="edges",
+            graph_block="GRUMPN",
+        )
+
+        self.assertIsInstance(model, models.KerasModel)
+
+        graph = (
+            tf.random.uniform((8, 10, 7)),  # Node features
+            tf.random.uniform((8, 50, 1)),  # Edge features
+            tf.random.uniform(
+                (8, 50, 2), minval=0, maxval=10, dtype=tf.int32
+            ),  # Edges
+            tf.random.uniform((8, 50, 2)),  # Edge dropouts
+        )
+        model.predict(graph)
 
 
 if __name__ == "__main__":

--- a/deeptrack/test/test_models.py
+++ b/deeptrack/test/test_models.py
@@ -140,7 +140,7 @@ class TestModels(unittest.TestCase):
             ),  # Edges
             tf.random.uniform((8, 50, 2)),  # Edge dropouts
         )
-        model.predict(graph)
+        model(graph)
 
     def test_CTMAGIK(self):
         model = models.CTMAGIK(
@@ -170,7 +170,7 @@ class TestModels(unittest.TestCase):
             ),  # Edges
             tf.random.uniform((8, 50, 2)),  # Edge dropouts
         )
-        prediction = model.predict(graph)
+        prediction = model(graph)
 
         self.assertEqual(prediction.shape, (8, 1))
 
@@ -204,7 +204,7 @@ class TestModels(unittest.TestCase):
             ),  # Edges
             tf.random.uniform((8, 50, 2)),  # Edge dropouts
         )
-        model.predict(graph)
+        model(graph)
 
     def test_MPGNN(self):
         model = models.MPNGNN(
@@ -234,7 +234,7 @@ class TestModels(unittest.TestCase):
             ),  # Edges
             tf.random.uniform((8, 50, 2)),  # Edge dropouts
         )
-        model.predict(graph)
+        model(graph)
 
     def test_MPGNN_readout(self):
         model = models.MPNGNN(
@@ -268,7 +268,7 @@ class TestModels(unittest.TestCase):
             ),  # Edges
             tf.random.uniform((8, 50, 2)),  # Edge dropouts
         )
-        prediction = model.predict(graph)
+        prediction = model(graph)
 
         self.assertEqual(prediction.shape, (8, 1))
 
@@ -301,7 +301,7 @@ class TestModels(unittest.TestCase):
             ),  # Edges
             tf.random.uniform((8, 50, 2)),  # Edge dropouts
         )
-        model.predict(graph)
+        model(graph)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request formats gnns/layers so that message-passing graph layers (MPNs) can be created easily and reused. Additionally, it includes new MPN layers (for example, vanilla MPN, GRUMPN, Masked FGNN) and convolutional graph layers (GraphTransformers).

Furthermore, it allows the calculation of masked attention scores using multi-head attention layers.